### PR TITLE
Fix crash and add leading comment for package

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,7 @@ impl ProtobufString for prost_types::FileDescriptorProto {
         // e.g. "foo", "foo.bar", etc.
         gen.path.push(2);
         if let Some(ref package) = self.package {
+            gen.write_leading_comment();
             gen.write_indent();
             gen.write("package ");
             gen.write(package);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,6 @@ impl Generator {
             for line in comment.lines() {
                 self.buf.push_str(&self.indent);
                 self.buf.push_str("//");
-                let line = line.clone();
                 self.buf.push_str(line);
                 self.buf.push_str("\n");
             }
@@ -100,14 +99,16 @@ impl Generator {
     }
 
     fn location(&self) -> Option<&prost_types::source_code_info::Location> {
-        let idx = self
+        let comment = self
             .source_info
             .as_ref()?
             .location
-            .binary_search_by_key(&&self.path[..], |location| &location.path[..])
-            .unwrap();
+            .binary_search_by_key(&&self.path[..], |location| &location.path[..]);
 
-        Some(&self.source_info.as_ref()?.location[idx])
+        match comment {
+            Ok(idx) => Some(&self.source_info.as_ref()?.location[idx]),
+            Err(_) => None,
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,14 +99,14 @@ impl Generator {
     }
 
     fn location(&self) -> Option<&prost_types::source_code_info::Location> {
-        let comment = self
+        let location = self
             .source_info
             .as_ref()?
             .location
             .binary_search_by_key(&&self.path[..], |location| &location.path[..]);
 
-        match comment {
-            Ok(idx) => Some(&self.source_info.as_ref()?.location[idx]),
+        match location {
+            Ok(location_idx) => Some(&self.source_info.as_ref()?.location[location_idx]),
             Err(_) => None,
         }
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -23,4 +23,3 @@ fn it_is_idempotent() {
         assert!(expected == actual);
     }
 }
-


### PR DESCRIPTION
The binary search returns `Error` when it doesn't find a location for a
path. The unwrap on the return value caused a panic, but in this case,
it should just return None. This caused crashes for files with leading
comments.

Additionally, supports comments leading the package name. They were
being dropped/ignored.